### PR TITLE
Make computedistances more general.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503

--- a/preprocessing/computedistances.py
+++ b/preprocessing/computedistances.py
@@ -1,39 +1,54 @@
 """Computes a pairwise distance matrix from a BLAST alignment."""
 
 import argparse
-from typing import Callable, TextIO, Tuple
+from typing import Dict, List, TextIO
 
 
-def short_hamming(ident: int, len1: int, len2: int) -> float:
-    """Compute the normalized Hamming distance between two sequences."""
+def short_hamming(record: Dict[str, str]) -> float:
+    """Compute a normalized hamming distance."""
+    len1 = int(record["qlen"])
+    len2 = int(record["slen"])
+    try:
+        ident = float(record["nident"])
+    except KeyError:
+        ident = float(record["length"]) * float(record["pident"]) / 100.0
     return 1 - ident / min(len1, len2)
 
 
-def parse_line(line: str, distance_metric: Callable) -> Tuple[str, str, float]:
+def hamming(record: Dict[str, str]) -> float:
+    """Compute the hamming distance."""
+    len1 = int(record["qlen"])
+    len2 = int(record["slen"])
+    try:
+        ident = float(record["nident"])
+    except KeyError:
+        ident = float(record["length"]) * float(record["pident"]) / 100.0
+    return max(len1, len2) - ident
+
+
+metric_dict = {"hamming": hamming, "short_hamming": short_hamming}
+
+
+def parse_line(line: str, fields: List[str]) -> Dict[str, str]:
     """Parse a line of BLAST+6 output.
 
     Parameters
     ----------
     line : str
-        A blast line in format `-outfmt "6 qacc sacc length qlen slen ident"`
-    distance_metric : Callable
-        A function that computes a distance metric from the info in `line`.
+    fields : List[str]
 
     Returns
     -------
-    query_accession : str
-        The query sequence accession.
-    subject_accession : str
-        The subject sequence accession.
-    distance : float
-        The distance between the sequences.
+    Dict[str, str]
+        A mapping between the fields and their values.
+
     """
-    qacc, sacc, length, qlen, slen, ident = line.split()
-    return qacc, sacc, distance_metric(int(ident), int(qlen), int(slen))
+    records = line.split()
+    return dict(zip(fields, records))
 
 
 def parse_file(
-    inputfile: TextIO, outputfile: TextIO, distance_metric: Callable
+    inputfile: TextIO, outputfile: TextIO, fields: str, distance_metric: str,
 ) -> None:
     r"""Parse blast+6 output and compute distances.
 
@@ -41,20 +56,27 @@ def parse_file(
     ----------
     inputfile : TextIO
         The input stream.
-        A blast file in format `-outfmt "6 qacc sacc length qlen slen ident"`
+        A blast file in format `-outfmt "6 <FIELDS>"`
     outputfile : TextIO
         The output stream.
         Will output in format "qacc\tsacc\tdistance\n"
-    distance_metric : Callable
-        A function that computes a distance metric from the info in `line`.
+    fields : str
+        A string containing the space-separated list of fields
+    distance_metric : str
+        A function that computes a distance metric from the fields.
 
     Returns
     -------
     None
 
     """
+    field_list = fields.split()
+    metric = metric_dict[distance_metric]
     for line in inputfile:
-        id1, id2, distance = parse_line(line, distance_metric)
+        record = parse_line(line, field_list)
+        id1 = record["qacc"]
+        id2 = record["sacc"]
+        distance = metric(record)
         outputfile.write(f"{id1}\t{id2}\t{distance}\n")
 
 
@@ -62,13 +84,15 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Parse blast output and compute distances."
     )
+
     parser.add_argument(
         "-i",
         "--inputfile",
         type=str,
         required=True,
-        help=r"Blast output generated with `-outfmt '6 qacc sacc length qlen slen ident'`",
+        help=r"Blast output generated with `-outfmt '6 <FIELDS>'`",
     )
+
     parser.add_argument(
         "-o",
         "--outputfile",
@@ -76,13 +100,26 @@ if __name__ == "__main__":
         required=True,
         help=r"Output in TSV format with fields qacc, tsacc, and distance",
     )
+
+    parser.add_argument(
+        "-f",
+        "--fields",
+        type=str,
+        required=True,
+        help=(
+            "A string containing the space-separated list of fields "
+            + "in the blast record."
+        ),
+    )
+
     parser.add_argument(
         "--distance_metric",
-        choices=["short_hamming"],
+        choices=list(metric_dict.keys()),
         default="short_hamming",
-        help="The distance metric to use. DEFAULT: short_hamming",
+        help="The distance metric to use. DEFAULT: hamming",
     )
+
     args = parser.parse_args()
     with open(args.inputfile, "r") as inputfile:
         with open(args.outputfile, "w") as outputfile:
-            parse_file(inputfile, outputfile, short_hamming)
+            parse_file(inputfile, outputfile, args.fields, args.distance_metric)

--- a/preprocessing/computedistances.py
+++ b/preprocessing/computedistances.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
         "--distance_metric",
         choices=list(metric_dict.keys()),
         default="short_hamming",
-        help="The distance metric to use. DEFAULT: hamming",
+        help="The distance metric to use. DEFAULT: short_hamming",
     )
 
     args = parser.parse_args()

--- a/tests/test_compute_distances.py
+++ b/tests/test_compute_distances.py
@@ -1,15 +1,17 @@
 from tempfile import TemporaryFile
 
-from preprocessing.computedistances import parse_file, short_hamming
+from preprocessing.computedistances import parse_file
 
 
 def test_parse_file():
     """Regression test for parse_file."""
+    fields = "qacc sacc length qlen slen nident"
+    distance_metric = "short_hamming"
     with open("example_data/2030446_distances.tsv", "r") as outputfile:
         target_output = outputfile.read()
     with TemporaryFile("wt+") as tf:
         with open("example_data/2030446.tsv", "r") as inputfile:
-            parse_file(inputfile, tf, short_hamming)
+            parse_file(inputfile, tf, fields, distance_metric)
             tf.seek(0)
             output = tf.read()
     assert output == target_output


### PR DESCRIPTION
The distance code now allows for the BLAST record to have arbitrary fields and distance metrics that use them. It depends on dictionary KeyErrors to guard against using metrics that don't have the right fields for the data, so probably could be made more user-friendly in the future.